### PR TITLE
Fix issue where `--restore_device` and similar commands don't work after running `--burn_mode`

### DIFF
--- a/superbird_tool.py
+++ b/superbird_tool.py
@@ -300,15 +300,7 @@ if __name__ == '__main__':
             dev.bulkcmd('env save')
             print('The device will now check for valid charger, requiring you to press menu button to bypass')
     elif args.burn_mode:
-        if check_device_mode('usb'):
-            print('Entering USB Burn Mode')
-            dev.bl2_boot('images/superbird.bl2.encrypted.bin', 'images/superbird.bootloader.img')
-            print('Waiting for device...')
-            time.sleep(5)  # wait for it to boot up in USB Burn Mode
-            if check_device_mode('usb-burn'):
-                print('Device is now in USB Burn Mode')
-            else:
-                print('Failed to enter USB Burn Mode!')
+        dev = enter_burn_mode(dev)
     elif args.continue_boot:
         if check_device_mode('usb-burn'):
             print('Continuing boot...')


### PR DESCRIPTION
Use the enter_burn_mode() function when running superbird-tool with `--burn_mode`. Fixes the issue where people can't run `--restore_device` and other similar commands after entering burn mode manually. This seems to be caused by the fact that `amlmmc part 1` isn't ran when entering burn mode. Also this simplifies the code a little bit.