### PR TITLE
Update macOS instructions to not require python from homebrew

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,12 +54,17 @@ and is missing `bulkcmd` functionality.
 ### macOS
 Tested on `aarch64` and `x86_64`
 
-On macOS, you must install `python3` and `libusb` from homebrew, and execute using that version of python
+On macOS, you must install `libusb` from homebrew. Additionally, if you have a `aarch64` mac, you will also need to install `pyusb` from the master branch as you'll need a workaround that is not present is the current pypy package.
+
+Tested with python `3.13.0`, installed via [pyenv](https://github.com/pyenv/pyenv).
+
 ```bash
-brew install python3 libusb
-/opt/homebrew/bin/python3 -m pip install git+https://github.com/superna9999/pyamlboot
-/opt/homebrew/bin/python3 superbird_tool.py --find_device
+brew install libusb
+python3 -m pip install git+https://github.com/pyusb/pyusb
+python3 -m pip install git+https://github.com/superna9999/pyamlboot
+python3 superbird_tool.py --find_device
 ```
+
 `root` is not needed on macOS
 
 ### Linux

--- a/superbird_device.py
+++ b/superbird_device.py
@@ -22,11 +22,12 @@ except ImportError:
     """)
     if platform.system() == 'Darwin':
         print("""
-        on macOS, you must install python3 and libusb from homebrew, 
-        and execute using that version of python
-            brew install python3 libusb
-            /opt/homebrew/bin/python3 -m pip install git+https://github.com/superna9999/pyamlboot
-            /opt/homebrew/bin/python3 superbird_tool.py
+        on macOS, you must install libusb from homebrew, 
+        and install pyusb from the master branch
+            brew install libusb
+            python3 -m pip install git+https://github.com/pyusb/pyusb
+            python3 -m pip install git+https://github.com/superna9999/pyamlboot
+            python3 superbird_tool.py
         root is not needed on macOS
         """)
     elif platform.system() == 'Linux':


### PR DESCRIPTION
The current instructions are not wrong, but they miss the problem. For some reason pyusb has issues finding libusb on arm64 macs, and a fix was pushed to master but not to the pypy package. While messing around with homebrew "solves" the problem, the correct solution here is to simply install pyusb from source. This allows users to skip installing python from homebrew if they already happen to have it from somewhere else (I use pyenv, for example).

I also added a note on the exact python version where I know this works, because I wouldn't be sure this works on any python3 version.